### PR TITLE
chore: add Dependabot config to keep GitHub Actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration that keeps the GitHub Actions used in this repo's workflows up to date.

## Details

- Creates `.github/dependabot.yml` with the `github-actions` package ecosystem.
- Scans the workflows in `/.github/workflows/` (`npm_release.yaml`, `pull_requests.yaml`, `update_client.yaml`).
- Checks for action version updates on a `weekly` schedule and opens PRs automatically when updates are available.

## Testing

No code changes; this is CI/maintenance configuration. Dependabot will validate and act on the config once merged.


---
*Created with [Bitly Shipyard](https://shipyard.bitly.pro/session/591b48cd34c88d327fc6f2a1ce88f331)*