### PR TITLE
chore: upgrade OpenAPI Generator CLI to 7.23.0

### DIFF
--- a/scripts/openapi-generator-cli.sh
+++ b/scripts/openapi-generator-cli.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 VENDOR_DIR=$SCRIPT_DIR/../vendor
 
 # https://github.com/OpenAPITools/openapi-generator/releases
-VERSION=7.21.0
+VERSION=7.23.0
 SOURCE=https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${VERSION}/openapi-generator-cli-${VERSION}.jar
 FILENAME=$(basename $SOURCE)
 mkdir -p $VENDOR_DIR


### PR DESCRIPTION
## Summary

Upgrades the OpenAPI Generator CLI version used in `scripts/openapi-generator-cli.sh` from `7.21.0` to `7.23.0`.

## Changes

- Bump `VERSION` from `7.21.0` to `7.23.0` in `scripts/openapi-generator-cli.sh`

See the [OpenAPI Generator releases](https://github.com/OpenAPITools/openapi-generator/releases) for the relevant changelog.


---
*Created with [Bitly Shipyard](https://shipyard.bitly.pro/session/04322692f98a173cf57fe3bad6dd11d0)*