### PR TITLE
Use npm trusted publishing (remove NODE_AUTH_TOKEN)

### DIFF
--- a/.github/workflows/npm_release.yaml
+++ b/.github/workflows/npm_release.yaml
@@ -15,8 +15,8 @@ jobs:
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary

The `npm_release.yaml` workflow already grants `id-token: write` and publishes with `--provenance`, which means it uses npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers) via OIDC. With trusted publishing, no long-lived auth token is needed, so the `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` is redundant.

## Changes

- Remove the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from the `npm publish` step.
- Add `npm install -g npm@latest` before publishing, since trusted publishing requires npm `>= 11.5.1` (newer than the version bundled with Node 22.x).

## Notes

This requires that a trusted publisher for this package be configured on npmjs.com (linking the repo + `npm_release.yaml` workflow). Once that's in place, the `NPM_TOKEN` secret can be removed from the repo.
