### PR TITLE
Fix extensions for CJS and ESM exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitly/api-client",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitly/api-client",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "tsdown": "^0.22.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitly/api-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Bitly API Client",
   "keywords": [
     "Bitly",
@@ -21,13 +21,13 @@
   "author": "",
   "type": "module",
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
       },
       "require": {
         "types": "./dist/index.d.cts",


### PR DESCRIPTION
Extensions weren't lining up for the exports list with how tsdown names them, making it still difficult to get the library installed.

This will update package version to `0.1.1`.